### PR TITLE
Ordering and simpler output for contests

### DIFF
--- a/commands/contest.go
+++ b/commands/contest.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"sort"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	interactor "github.com/tuupke/api-interactor"
@@ -24,17 +26,34 @@ func fetchContests(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not connect to the API; %w", err)
 	}
 
-	var c interface{}
 	if contestId != "" {
-		c, err = api.ContestById(contestId)
+		c, err := api.ContestById(contestId)
+
+		if err != nil {
+			return fmt.Errorf("could not retrieve contest; %w", err)
+		}
+
+		fmt.Printf(" %10s: %s\n", c.Id, c.Name)
+		fmt.Printf("             %v starting at %v\n", c.Duration, c.StartTime)
 	} else {
-		c, err = api.Contests()
+		c, err := api.Contests()
+
+		if err != nil {
+			return fmt.Errorf("could not retrieve contests; %w", err)
+		}
+
+		// sort by start time
+		sort.Slice(c, func(i, j int) bool {
+			return c[i].StartTime.Time().Before(c[j].StartTime.Time())
+		})
+
+		// output
+		fmt.Printf("Contests (%d):\n", len(c))
+		for _, o := range c {
+			fmt.Printf(" %10s: %s\n", o.Id, o.Name)
+			fmt.Printf("             %v starting at %v\n", o.Duration, o.StartTime)
+		}
 	}
 
-	if err != nil {
-		return fmt.Errorf("could not retrieve contests; %w", err)
-	}
-
-	fmt.Println(c)
 	return nil
 }


### PR DESCRIPTION
Order contests by start time and output in a simple two-line format.