### PR TITLE
Submit clarification with problem label

### DIFF
--- a/commands/post_clar.go
+++ b/commands/post_clar.go
@@ -19,6 +19,22 @@ func postClarification(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not connect to the API; %w", err)
 	}
 
+	if problemId != "" {
+		// Get the problems and languages
+		problems, err := api.Problems()
+		if err != nil {
+			return fmt.Errorf("could not get problems; %w", err)
+		}
+
+		problem, hasProblem := problemSet(problems).byId(problemId)
+
+		if !hasProblem {
+			return fmt.Errorf("no known problem specified")
+		}
+
+		problemId = problem.Id
+	}
+
 	clarId, err := api.PostClarification(problemId, args[0])
 
 	if err != nil {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -29,7 +29,7 @@ type (
 
 func (p problemSet) byId(id string) (interactor.Problem, bool) {
 	for _, problem := range p {
-		if strings.EqualFold(problem.Id, id) || strings.EqualFold(problem.Label, id) {
+		if strings.EqualFold(problem.Id, id) || strings.EqualFold(problem.Label, id) || strings.EqualFold(problem.Name, id) {
 			return problem, true
 		}
 	}


### PR DESCRIPTION
When submitting a clarification this verifies --problem if it exists, and allows it to be the problem id ("hobson"), label ("H"), or name ("Hobson's Trains"). Adding the name also allows problem name to be used when submitting.