### PR TITLE
Listing clarifications

### DIFF
--- a/commands/clar.go
+++ b/commands/clar.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var clarCommand = &cobra.Command{
+	Use:     "clar",
+	Short:   "Get clarifications",
+	RunE:    fetchClars,
+	PreRunE: configHelper("baseurl", "contest"),
+}
+
+func fetchClars(cmd *cobra.Command, args []string) error {
+	api, err := contestApi()
+	if err != nil {
+		return fmt.Errorf("could not connect to the API; %w", err)
+	}
+
+	clars, err := api.Clarifications()
+
+	if err != nil {
+		return fmt.Errorf("could not retrieve clarifications; %w", err)
+	}
+
+	// output
+	fmt.Printf("Clarifications (%d):\n", len(clars))
+	for _, o := range clars {
+		if o.FromTeamId == "" && o.ToTeamId == "" {
+			fmt.Printf("  Broadcast message from jury at %v", o.ContestTime)
+		} else if o.FromTeamId != "" {
+			fmt.Printf("  Clarification sent to jury at %v", o.ContestTime)
+		} else {
+			fmt.Printf("  Response from jury at %v", o.ContestTime)
+		}
+		if o.ProblemId != "" {
+			problems, err := api.Problems()
+			if err != nil {
+				return fmt.Errorf("could not get problems; %w", err)
+			}
+
+			problem, hasProblem := problemSet(problems).byId(o.ProblemId)
+			if !hasProblem {
+				fmt.Printf(" for unknown problem")
+			}
+
+			fmt.Printf(" for problem %s (%s)", problem.Label, problem.Name)
+		}
+		fmt.Printf(":\n")
+		lines := strings.Split(o.Text, "\n")
+		for _, s := range lines {
+			fmt.Printf("     %s\n", s)
+		}
+	}
+
+	return nil
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
 	"github.com/kirsle/configdir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	interactor "github.com/tuupke/api-interactor"
-	"os"
-	"path/filepath"
-	"reflect"
 )
 
 const (
@@ -93,6 +94,7 @@ are not supplied, they are read from the configuration file (%s)`, rootCommand.S
 
 	// Register the subcommands
 	rootCommand.AddCommand(contestCommand)
+	rootCommand.AddCommand(clarCommand)
 	rootCommand.AddCommand(postClarCommand)
 	rootCommand.AddCommand(problemCommand)
 	rootCommand.AddCommand(loginCommand)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tuupke/api-interactor v0.0.0-20210428200732-71c16d198e15
+	github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
 	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tuupke/api-interactor v0.0.0-20210428200732-71c16d198e15 h1:zcRyJcvVHkjo5bvKjpyboxXzjEZcMMXOap0l9+GtBjo=
 github.com/tuupke/api-interactor v0.0.0-20210428200732-71c16d198e15/go.mod h1:kF34HEok3lfUGZzPavpwIRupJfydd3ndqWz0Aua1/j8=
+github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333 h1:RKhP4r+9z+ELnI+Ad4IeUHlHUvj4Kz5zzbZPU/Z98Ug=
+github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333/go.mod h1:kF34HEok3lfUGZzPavpwIRupJfydd3ndqWz0Aua1/j8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
This could use more work and maybe there's a better way to output clarifications, but for now it adds the initial command ("clar" for now) to list all of the team's clarifications. Each clarification is output with a message to say whether the team submitted it, it's a response, or a broadcast. The contest time is also shown, if it was associated with a problem, and the text, e.g.:

Clarifications (2):
  Clarification sent to jury at 1h38m58.21s for problem E (Dead-End Detector):
     In case n = 2 and m = 1, there are two solutions:
     1 2
     and
     2 1

     Is it allowed to print any of them?
  Response from jury at 1h39m54.235s for problem E (Dead-End Detector):
     > In case n = 2 and m = 1, there are two solutions:
     > 1 2
     > and
     > 2 1
     >
     > Is it allowed to print any of them?

     No comment