### PR TITLE
Default to the best contest

### DIFF
--- a/commands/clar.go
+++ b/commands/clar.go
@@ -11,7 +11,7 @@ var clarCommand = &cobra.Command{
 	Use:     "clar",
 	Short:   "Get clarifications",
 	RunE:    fetchClars,
-	PreRunE: configHelper("baseurl", "contest"),
+	PreRunE: configHelper("baseurl"),
 }
 
 func fetchClars(cmd *cobra.Command, args []string) error {

--- a/commands/post_clar.go
+++ b/commands/post_clar.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +11,7 @@ var postClarCommand = &cobra.Command{
 	Short:   "Post a clarification",
 	Args:    cobra.ExactValidArgs(1),
 	RunE:    postClarification,
-	PreRunE: configHelper("baseurl", "contest"),
+	PreRunE: configHelper("baseurl"),
 }
 
 func postClarification(cmd *cobra.Command, args []string) error {

--- a/commands/problem.go
+++ b/commands/problem.go
@@ -2,15 +2,16 @@ package commands
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"sort"
+
+	"github.com/spf13/cobra"
 )
 
 var problemCommand = &cobra.Command{
 	Use:     "problem",
 	Short:   "Get problems",
 	RunE:    fetchProblems,
-	PreRunE: configHelper("baseurl", "contest"),
+	PreRunE: configHelper("baseurl"),
 }
 
 func fetchProblems(cmd *cobra.Command, args []string) error {

--- a/commands/root.go
+++ b/commands/root.go
@@ -209,7 +209,7 @@ func (c contestSet) bestContest() (interactor.Contest, error) {
 
 	if count == 1 {
 		return best, nil
-	} else if count == 2 {
+	} else if count >= 2 {
 		return interactor.Contest{}, errors.New("more than one contest is currently running")
 	}
 	if unscheduled == len(c) {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -19,7 +19,7 @@ var submitCommand = &cobra.Command{
 	Short:   "Submit one or more files",
 	Args:    cobra.MinimumNArgs(1),
 	RunE:    submit,
-	PreRunE: configHelper("baseurl", "contest"),
+	PreRunE: configHelper("baseurl"),
 }
 
 type (


### PR DESCRIPTION
This change allows you to use most commands without specifying a contest id. If the API can connect and determine a "best" contest (e.g. if there is only one running contest or only one today) then it'll output a message and automatically connect to that one.

The algorithm is fairly simple and could likely be improved in the future, but it works for all the cases I could think of. This change covers the following commands: contest, clar, post-clar, and problem. Note that the submit command is *not* complete since it uses the config string directly - I'll submit another PR for that.