### PR TITLE
Improve contest start times

### DIFF
--- a/commands/contest.go
+++ b/commands/contest.go
@@ -3,14 +3,36 @@ package commands
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/spf13/cobra"
+	interactor "github.com/tuupke/api-interactor"
 )
 
 var contestCommand = &cobra.Command{
 	Use:   "contest",
 	Short: "Get contests",
 	RunE:  fetchContests,
+}
+
+func outputContest(c interactor.Contest) {
+	fmt.Printf(" %10s: %s\n", c.Id, c.Name)
+	if c.StartTime == (interactor.ApiTime{}) {
+		if c.CountdownTime != interactor.ApiRelTime(0) {
+			fmt.Printf("             %v (countdown paused at %s)\n", c.Duration, c.CountdownTime)
+		} else {
+			fmt.Printf("             %v (not scheduled)\n", c.Duration)
+		}
+	} else {
+		now := time.Now()
+		if c.StartTime.Time().After(now) {
+			fmt.Printf("             %v starting at %v\n", c.Duration, c.StartTime)
+		} else if (c.StartTime.Time().Add(c.Duration.Duration())).After(now) {
+			fmt.Printf("             Contest running. %v started at %v\n", c.Duration, c.StartTime)
+		} else {
+			fmt.Printf("             Contest over. Started at %v\n", c.StartTime)
+		}
+	}
 }
 
 func fetchContests(cmd *cobra.Command, args []string) error {
@@ -26,8 +48,7 @@ func fetchContests(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("could not retrieve contest; %w", err)
 		}
 
-		fmt.Printf(" %10s: %s\n", c.Id, c.Name)
-		fmt.Printf("             %v starting at %v\n", c.Duration, c.StartTime)
+		outputContest(c)
 	} else {
 		c, err := api.Contests()
 
@@ -43,8 +64,7 @@ func fetchContests(cmd *cobra.Command, args []string) error {
 		// output
 		fmt.Printf("Contests (%d):\n", len(c))
 		for _, o := range c {
-			fmt.Printf(" %10s: %s\n", o.Id, o.Name)
-			fmt.Printf("             %v starting at %v\n", o.Duration, o.StartTime)
+			outputContest(o)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tuupke/api-interactor v0.0.0-20210504224002-5198e57eec91

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333
+	github.com/tuupke/api-interactor v0.0.0-20210504224002-5198e57eec91
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
 	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,10 +197,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tuupke/api-interactor v0.0.0-20210428200732-71c16d198e15 h1:zcRyJcvVHkjo5bvKjpyboxXzjEZcMMXOap0l9+GtBjo=
-github.com/tuupke/api-interactor v0.0.0-20210428200732-71c16d198e15/go.mod h1:kF34HEok3lfUGZzPavpwIRupJfydd3ndqWz0Aua1/j8=
-github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333 h1:RKhP4r+9z+ELnI+Ad4IeUHlHUvj4Kz5zzbZPU/Z98Ug=
-github.com/tuupke/api-interactor v0.0.0-20210503195646-d6eacdbff333/go.mod h1:kF34HEok3lfUGZzPavpwIRupJfydd3ndqWz0Aua1/j8=
+github.com/tuupke/api-interactor v0.0.0-20210504224002-5198e57eec91 h1:UnedmTxjY1GYFyXipRLK10V1GSn+ka34OBB2Kj3RTjM=
+github.com/tuupke/api-interactor v0.0.0-20210504224002-5198e57eec91/go.mod h1:kF34HEok3lfUGZzPavpwIRupJfydd3ndqWz0Aua1/j8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
When a contest start time is empty (returns null in json - not scheduled, or countdown paused) the output from the `contest` command is a little bizarre due to Go's nil type (and my not thinking about it before):
     finals: ICPC World Finals 2019
             5h0m0s starting at 0001-01-01 00:00:00 +0000 UTC

While fixing this I expanded it to include the following output:
     finals: ICPC World Finals 2019
             5h0m0s (not scheduled)
     finals: ICPC World Finals 2019
             5h0m0s (countdown paused at 5m34)
     finals: ICPC World Finals 2019
             5h0m0s starting at 2019-04-04 06:50:25 -0400 EDT
     finals: ICPC World Finals 2019
             Contest running. 5h0m0s started at 2019-04-04 06:50:25 -0400 EDT
     finals: ICPC World Finals 2019
             Contest over. Started at 2019-04-04 06:50:25 -0400 EDT