### PR TITLE
Submissions command

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -106,6 +106,7 @@ are not supplied, they are read from the configuration file (%s)`, rootCommand.S
 	rootCommand.AddCommand(logoutCommand)
 	rootCommand.AddCommand(setCommand)
 	rootCommand.AddCommand(submitCommand)
+	rootCommand.AddCommand(submissionsCommand)
 }
 
 // configHelper can be used to register which flags must exist. An error is thrown when a required flag is not present

--- a/commands/submissions.go
+++ b/commands/submissions.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	interactor "github.com/tuupke/api-interactor"
+)
+
+var submissionsCommand = &cobra.Command{
+	Use:     "submissions",
+	Short:   "Shows past submissions and their judgements",
+	RunE:    submissions,
+	PreRunE: configHelper("baseurl"),
+}
+
+type (
+	judgementTypeSet []interactor.JudgementType
+	judgementSet     []interactor.Judgement
+)
+
+func (j judgementTypeSet) byId(id string) (interactor.JudgementType, bool) {
+	for _, jt := range j {
+		if jt.Id == id {
+			return jt, true
+		}
+	}
+
+	return interactor.JudgementType{}, false
+}
+
+func (j judgementSet) bySubmissionId(id string) (judgementSet, bool) {
+	var jud []interactor.Judgement
+	for _, ju := range j {
+		if ju.SubmissionId == id {
+			jud = append(jud, ju)
+		}
+	}
+
+	return jud, len(jud) > 0
+}
+
+func submissions(cmd *cobra.Command, args []string) error {
+	api, err := contestApi()
+	if err != nil {
+		return fmt.Errorf("could not connect to the API; %w", err)
+	}
+
+	// Get the problems, languages, and judgementTypes
+	problems, err := api.Problems()
+	if err != nil {
+		return fmt.Errorf("could not get problems; %w", err)
+	}
+
+	languages, err := api.Languages()
+	if err != nil {
+		return fmt.Errorf("could not get languages; %w", err)
+	}
+
+	judgementTypes, err := api.JudgementTypes()
+	if err != nil {
+		return fmt.Errorf("could not get judgement types; %w", err)
+	}
+
+	submissions, err := api.Submissions()
+	if err != nil {
+		return fmt.Errorf("could not get submissions; %w", err)
+	}
+
+	judgements, err := api.Judgements()
+	if err != nil {
+		return fmt.Errorf("could not get judgements; %w", err)
+	}
+
+	teamId := "1"
+
+	// sort by submission time
+	sort.Slice(submissions, func(i, j int) bool {
+		return submissions[i].ContestTime.Duration() < submissions[j].ContestTime.Duration()
+	})
+
+	count := 0
+	for _, s := range submissions {
+		if strings.EqualFold(s.TeamId, teamId) {
+			count++
+		}
+	}
+
+	fmt.Printf("Submissions (%d):\n", count)
+	for _, s := range submissions {
+		if s.TeamId == teamId {
+			fmt.Printf("  Submission to ")
+
+			problem, hasProblem := problemSet(problems).byId(s.ProblemId)
+			if hasProblem {
+				fmt.Printf("problem %s: %s", problem.Label, problem.Name)
+			} else {
+				fmt.Printf("unknown problem")
+			}
+
+			language, hasLanguage := languageSet(languages).byId(s.LanguageId)
+			if hasLanguage {
+				fmt.Printf(" in %s", language.Name)
+			} else {
+				fmt.Printf(" in unknown language")
+			}
+			fmt.Printf(" at %s\n", s.ContestTime)
+
+			// Get judgement
+			sjudgements, hasJudgements := judgementSet(judgements).bySubmissionId(s.Id)
+			if hasJudgements {
+				for _, j := range sjudgements {
+					if j.JudgementTypeId != "" {
+						judgementType, hasjudgementType := judgementTypeSet(judgementTypes).byId(j.JudgementTypeId)
+						if hasjudgementType {
+							fmt.Printf("     Judged at %s: %s (%s)\n", j.EndContestTime, judgementType.Id, judgementType.Name)
+						} else {
+							fmt.Printf("     Unknown judgement at %s\n", j.EndContestTime)
+						}
+					} else {
+						fmt.Printf("     Judgement in progress\n")
+					}
+				}
+			} else {
+				fmt.Println("     Not judged")
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds a command to list all of a team's submissions, and their judgements, e.g.:
```
./contest submissions
Automatically connecting to contest: ICPC World Finals 2019
Submissions (11):
  Submission to problem J: Miniature Golf in C++ at 34m14.979s
     Judged at 34m18.925s: WA (wrong answer)
  Submission to problem A: Azulejos in C++ at 1h1m4.046s
     Judged at 1h1m22.299s: AC (correct)
  Submission to problem E: Dead-End Detector in C++ at 1h41m34.267s
     Judged at 1h41m40.449s: WA (wrong answer)
```

Note this is _hard-coded_ to team id "1" on line 77. The intention is that the role API being discussed at the CLICS meetings will provide a way to dynamically determine which team the current user belongs to.