### PR TITLE
Tables for contests, problems

### DIFF
--- a/commands/problem.go
+++ b/commands/problem.go
@@ -21,7 +21,6 @@ func fetchProblems(cmd *cobra.Command, args []string) error {
 	}
 
 	p, err := api.Problems()
-
 	if err != nil {
 		return fmt.Errorf("could not retrieve problems; %w", err)
 	}
@@ -32,10 +31,15 @@ func fetchProblems(cmd *cobra.Command, args []string) error {
 	})
 
 	// output
-	fmt.Printf("Problems (%d):\n", len(p))
+	fmt.Printf("\nProblems (%d):\n", len(p))
+
+	var table = Table{}
+	table.Header = []string{"Label", "Name"}
+	table.Align = []int{ALIGN_LEFT, ALIGN_LEFT}
 	for _, o := range p {
-		fmt.Printf(" %3s: %s\n", o.Label, o.Name)
+		table.appendRow([]string{o.Label, o.Name})
 	}
+	table.print()
 
 	return nil
 }


### PR DESCRIPTION
- Modified the table in scoreboard.go slightly to have one space to the left and right of every column instead of two to the left. Added an appendRow() and fixed scoreboard to use display name.
- Switch contests and problems to the same table output and added support for formal name (only showing the one name for now).

Example output below:
```
Contests (2):
   Id      Name                    Start Time                     Length  Status
   finals  ICPC World Finals 2019  2019-04-04 06:50:25 -0400 EDT  5h0m0s  Contest over
   comm    practice                2020-02-21 09:57:00 -0500 EST  2h0m0s  Contest over

Problems (11):
   Label  Name
   A      Azulejos
   B      Beautiful Bridges
   C      Checks Post Facto
...
```