### PR TITLE
Don't output usage if args are correct

### DIFF
--- a/commands/clar.go
+++ b/commands/clar.go
@@ -10,15 +10,17 @@ import (
 
 var clarCommand = &cobra.Command{
 	Use:     "clar",
-	Short:   "Get clarifications",
+	Short:   "List clarifications",
+	Args:    cobra.NoArgs,
 	RunE:    fetchClars,
 	PreRunE: configHelper("baseurl"),
 }
 
 func fetchClars(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
-		return fmt.Errorf("could not connect to the API; %w", err)
+		return fmt.Errorf("could not connect to the server; %w", err)
 	}
 
 	clars, err := api.Clarifications()

--- a/commands/contest.go
+++ b/commands/contest.go
@@ -11,7 +11,7 @@ import (
 
 var contestCommand = &cobra.Command{
 	Use:   "contest",
-	Short: "Get contests",
+	Short: "List contests",
 	RunE:  fetchContests,
 }
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -16,6 +16,7 @@ var loginCommand = &cobra.Command{
 }
 
 func login(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	viper.Set("username", args[0])
 	viper.Set("password", args[1])
 	if err := viper.WriteConfigAs(configFile()); err != nil {

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -14,6 +15,7 @@ var logoutCommand = &cobra.Command{
 }
 
 func logout(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	viper.Set("username", "")
 	viper.Set("password", "")
 	if err := viper.WriteConfigAs(configFile()); err != nil {

--- a/commands/post_clar.go
+++ b/commands/post_clar.go
@@ -15,6 +15,7 @@ var postClarCommand = &cobra.Command{
 }
 
 func postClarification(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
 		return fmt.Errorf("could not connect to the server; %w", err)

--- a/commands/problem.go
+++ b/commands/problem.go
@@ -9,15 +9,17 @@ import (
 
 var problemCommand = &cobra.Command{
 	Use:     "problem",
-	Short:   "Get problems",
+	Short:   "List problems",
+	Args:    cobra.NoArgs,
 	RunE:    fetchProblems,
 	PreRunE: configHelper("baseurl"),
 }
 
 func fetchProblems(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
-		return fmt.Errorf("could not connect to the API; %w", err)
+		return fmt.Errorf("could not connect to the server; %w", err)
 	}
 
 	p, err := api.Problems()

--- a/commands/scoreboard.go
+++ b/commands/scoreboard.go
@@ -9,14 +9,16 @@ import (
 var scoreboardCommand = &cobra.Command{
 	Use:     "scoreboard",
 	Short:   "Show the contest scoreboard",
+	Args:    cobra.NoArgs,
 	RunE:    scoreboard,
 	PreRunE: configHelper("baseurl"),
 }
 
 func scoreboard(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
-		return fmt.Errorf("could not connect to the API; %w", err)
+		return fmt.Errorf("could not connect to the server; %w", err)
 	}
 
 	problems, err := api.Problems()

--- a/commands/set.go
+++ b/commands/set.go
@@ -30,6 +30,7 @@ var setIdCommand = &cobra.Command{
 }
 
 func setUrl(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	viper.Set("baseurl", args[0])
 	if err := viper.WriteConfigAs(configFile()); err != nil {
 		return err
@@ -40,6 +41,7 @@ func setUrl(cmd *cobra.Command, args []string) error {
 }
 
 func setId(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	viper.Set("contest", args[0])
 	if err := viper.WriteConfigAs(configFile()); err != nil {
 		return err

--- a/commands/submissions.go
+++ b/commands/submissions.go
@@ -10,15 +10,17 @@ import (
 
 var submissionsCommand = &cobra.Command{
 	Use:     "submissions",
-	Short:   "Shows past submissions and their judgements",
+	Short:   "List past submissions and their judgements",
+	Args:    cobra.NoArgs,
 	RunE:    submissions,
 	PreRunE: configHelper("baseurl"),
 }
 
 func submissions(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
-		return fmt.Errorf("could not connect to the API; %w", err)
+		return fmt.Errorf("could not connect to the server; %w", err)
 	}
 
 	// Get the problems, languages, and judgementTypes

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -23,6 +23,7 @@ var submitCommand = &cobra.Command{
 }
 
 func submit(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	api, err := contestApi()
 	if err != nil {
 		return fmt.Errorf("could not connect to the server; %w", err)


### PR DESCRIPTION
- Added 'cmd.SilenceUsage = true' consistently so that the usage is output if the args are incorrect, but not if there are other problems, e.g. communication error. See https://github.com/spf13/cobra/issues/340 for background on why it's done this way.
- Added a few missing argument validations.
- Nit in terminology: changed "get" to "list" and "API" to "server"